### PR TITLE
UMP v3 token support with Argon2id password KDF

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,5 +2,11 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testPathIgnorePatterns: ['dist/']
+  testPathIgnorePatterns: ['dist/'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }]
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@bsv/overlay": "^0.5.3",
-        "@bsv/sdk": "^1.9.3",
+        "@bsv/overlay": "^2.0.2",
+        "@bsv/sdk": "^2.0.13",
         "knex": "^3.1.0",
         "mongodb": "^6.11.0"
       },
@@ -491,29 +491,29 @@
       "dev": true
     },
     "node_modules/@bsv/gasp": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@bsv/gasp/-/gasp-1.2.0.tgz",
-      "integrity": "sha512-gLWS8gpbcaKjYgF0LVj1N6M6FGw9iIWu8WY77mKspVqaXmCwbazVPbDcH7Is7dvUhadqkvYXyF4cXj7TLxhYFQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@bsv/gasp/-/gasp-1.2.2.tgz",
+      "integrity": "sha512-2YylMdPUPFN2+mo2GmnaIosHkM4ZpNm6Nq+dMFS3TrH2hmrl7kDoNrBUy0oqSIq1xKqC+XjuHdDy6LNRB4yjSA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@bsv/sdk": "^1.6.12"
+        "@bsv/sdk": "^2.0.0"
       }
     },
     "node_modules/@bsv/overlay": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@bsv/overlay/-/overlay-0.5.3.tgz",
-      "integrity": "sha512-HOtWKzLtLDEFNCZ6NbGnd25dpyBqJxwXIROFVKZbh7MQsa5Tm4BOMsmKFST9WHG3AFaaiP3WIFPLEdIAA3bXhA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@bsv/overlay/-/overlay-2.0.2.tgz",
+      "integrity": "sha512-XGwnz+OhBaXweXK46gfFhIy2qvmODsbpOCTwAnmGTrvRNA1c4uza5vAQlB9Yo/rCytaUKvU3R/GE72cVN1xNfg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@bsv/gasp": "^1.2.0",
-        "@bsv/sdk": "^1.9.1",
+        "@bsv/gasp": "^1.2.2",
+        "@bsv/sdk": "^2.0.4",
         "knex": "^3.1.0"
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.9.3.tgz",
-      "integrity": "sha512-EObOijv0p3eKJgXkxCKrKCGdKtWwKpxnoIRRS7TJk9DHB+3TFMNd8f5bdPSjE4yQ1mWbBXeYFlkCGlDBR3rK1w==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.0.13.tgz",
+      "integrity": "sha512-VV25sV6oB1Piu7tTEMta+B29IRcq7Xpj1ohuk8RZRT656onop1YbA3oTnYf6stleWnbvsZeOciwH7Xppvs1QWw==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -566,22 +566,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -604,22 +588,17 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
@@ -1505,6 +1484,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -3226,22 +3222,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3320,22 +3300,17 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
@@ -3608,10 +3583,11 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3693,10 +3669,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -5315,10 +5292,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5356,6 +5334,13 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5532,9 +5517,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5663,10 +5649,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7967,9 +7954,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
+        "mongodb-memory-server": "^10.4.3",
         "ts-jest": "^29.1.1",
         "ts-standard": "^12.0.2",
         "ts2md": "^0.2.0",
@@ -1496,6 +1497,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1731,6 +1742,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1744,6 +1772,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -1862,6 +1905,99 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
+      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.0.tgz",
+      "integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
+      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.21.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1944,6 +2080,16 @@
       "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -2165,6 +2311,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2264,10 +2417,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3305,6 +3459,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3358,6 +3522,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3460,6 +3631,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3492,6 +3697,27 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3867,6 +4093,20 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -5497,6 +5737,85 @@
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.4.3.tgz",
+      "integrity": "sha512-CDZvFisXvGIigsIw5gqH6r9NI/zxGa/uRdutgUL/isuJh+inj0YXb7Ykw6oFMFzqgTJWb7x0I5DpzrqCstBWpg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.4.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.4.3.tgz",
+      "integrity": "sha512-IPjlw73IoSYopnqBibQKxmAXMbOEPf5uGAOsBcaUiNH/TOI7V19WO+K7n5KYtnQ9FqzLGLpvwCGuPOTBSg4s5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.11",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^6.9.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/mongodb-memory-server/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5514,6 +5833,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5842,6 +6174,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pg-connection-string": {
       "version": "2.6.2",
@@ -6736,6 +7075,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -6921,12 +7272,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tarn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
       "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/test-exclude": {
@@ -6941,6 +7315,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -7578,6 +7962,20 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@bsv/overlay": "^2.0.2",
         "@bsv/sdk": "^2.0.13",
-        "knex": "^3.1.0",
         "mongodb": "^6.11.0"
       },
       "devDependencies": {
@@ -21,7 +20,6 @@
         "ts-jest": "^29.1.1",
         "ts-standard": "^12.0.2",
         "ts2md": "^0.2.0",
-        "tsconfig-to-dual-package": "^1.2.0",
         "typescript": "^5.2.2"
       }
     },
@@ -1581,17 +1579,20 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
-      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "is-string": "^1.0.7"
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1722,12 +1723,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2549,21 +2544,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.119",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.119.tgz",
@@ -2598,27 +2578,28 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
         "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
+        "call-bound": "^1.0.4",
         "data-view-buffer": "^1.0.2",
         "data-view-byte-length": "^1.0.2",
         "data-view-byte-offset": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "es-set-tostringtag": "^2.1.0",
         "es-to-primitive": "^1.3.0",
         "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.0",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
         "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
@@ -2630,21 +2611,24 @@
         "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
         "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
         "is-shared-array-buffer": "^1.0.4",
         "is-string": "^1.1.1",
         "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.0",
+        "is-weakref": "^1.1.1",
         "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.3",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.7",
         "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.3",
+        "regexp.prototype.flags": "^1.5.4",
         "safe-array-concat": "^1.1.3",
         "safe-push-apply": "^1.0.0",
         "safe-regex-test": "^1.1.0",
         "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
         "string.prototype.trim": "^1.2.10",
         "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
@@ -2653,7 +2637,7 @@
         "typed-array-byte-offset": "^1.0.4",
         "typed-array-length": "^1.0.7",
         "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.18"
+        "which-typed-array": "^1.1.19"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2926,10 +2910,11 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
-      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7"
       },
@@ -2947,6 +2932,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -2995,29 +2981,30 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.8",
-        "array.prototype.findlastindex": "^1.2.5",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.0",
+        "eslint-module-utils": "^2.12.1",
         "hasown": "^2.0.2",
-        "is-core-module": "^2.15.1",
+        "is-core-module": "^2.16.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.8",
         "object.groupby": "^1.0.3",
-        "object.values": "^1.2.0",
+        "object.values": "^1.2.1",
         "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimend": "^1.0.9",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
@@ -3101,10 +3088,11 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.37.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
-      "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -3116,7 +3104,7 @@
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.8",
+        "object.entries": "^1.1.9",
         "object.fromentries": "^2.0.8",
         "object.values": "^1.2.1",
         "prop-types": "^15.8.1",
@@ -3563,38 +3551,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3978,6 +3934,28 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4411,6 +4389,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4698,24 +4689,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -5821,6 +5794,13 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/new-find-package-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
@@ -6181,10 +6161,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6561,22 +6542,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/resolve-tsconfig": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/resolve-tsconfig/-/resolve-tsconfig-1.3.0.tgz",
-      "integrity": "sha512-Ba5mo3soshb2CnIcNFz75F/80H/2eMVxrlmdgoSDNH7Lr6UAoT3BvxNtc7+VXqKSBlC0SJk2qSXOTcy0/p7cFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=16",
-        "pnpm": ">=7"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/skarab42"
-      },
-      "peerDependencies": {
-        "typescript": "*"
       }
     },
     "node_modules/resolve.exports": {
@@ -7062,6 +7027,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -7358,19 +7337,20 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz",
-      "integrity": "sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
+        "handlebars": "^4.7.8",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.1",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -7381,10 +7361,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -7402,19 +7383,36 @@
         },
         "esbuild": {
           "optional": true
+        },
+        "jest-util": {
+          "optional": true
         }
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-standard": {
@@ -7490,24 +7488,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/tsconfig-to-dual-package": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-to-dual-package/-/tsconfig-to-dual-package-1.2.0.tgz",
-      "integrity": "sha512-UtMinqTLfWr9fX6KidLsEcCJoA/jSLPIS00ohpQybMSxA3LlJCRf2DsGPw4AJJ8AP4FOHfbQJFJ5XgLoL7RoLw==",
-      "dev": true,
-      "dependencies": {
-        "resolve-tsconfig": "^1.3.0"
-      },
-      "bin": {
-        "tsconfig-to-dual-package": "bin/cmd.mjs"
-      },
-      "engines": {
-        "node": ">=18.3.0 || >=16.17.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.0.0"
       }
     },
     "node_modules/tslib": {
@@ -7649,6 +7629,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -7865,6 +7859,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
+    "mongodb-memory-server": "^10.4.3",
     "ts-jest": "^29.1.1",
     "ts-standard": "^12.0.2",
     "ts2md": "^0.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,8 +44,8 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@bsv/overlay": "^0.5.3",
-    "@bsv/sdk": "^1.9.3",
+    "@bsv/overlay": "^2.0.2",
+    "@bsv/sdk": "^2.0.13",
     "knex": "^3.1.0",
     "mongodb": "^6.11.0"
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,13 +40,11 @@
     "ts-jest": "^29.1.1",
     "ts-standard": "^12.0.2",
     "ts2md": "^0.2.0",
-    "tsconfig-to-dual-package": "^1.2.0",
     "typescript": "^5.2.2"
   },
   "dependencies": {
     "@bsv/overlay": "^2.0.2",
     "@bsv/sdk": "^2.0.13",
-    "knex": "^3.1.0",
     "mongodb": "^6.11.0"
   }
 }

--- a/backend/src/__tests/UMPLookupServiceFactory.test.ts
+++ b/backend/src/__tests/UMPLookupServiceFactory.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { MongoClient, Db } from 'mongodb'
+import UMPLookupServiceFactory from '../lookup-services/UMPLookupServiceFactory.js'
+import { Utils, PrivateKey, LockingScript } from '@bsv/sdk'
+import type { UMPRecord } from '../types.js'
+
+// Builds a PushDrop-formatted locking script without needing a real wallet
+function buildPushDropScript(fields: number[][]): LockingScript {
+  const pubKeyBytes = PrivateKey.fromRandom().toPublicKey().toDER() as number[]
+
+  const encodeChunk = (data: number[]): { op: number; data?: number[] } => {
+    if (data.length === 0) return { op: 0 }
+    if (data.length === 1 && data[0] === 0) return { op: 0 }
+    if (data.length === 1 && data[0] > 0 && data[0] <= 16) return { op: 0x50 + data[0] }
+    if (data.length === 1 && data[0] === 0x81) return { op: 0x4f }
+    if (data.length <= 75) return { op: data.length, data }
+    if (data.length <= 255) return { op: 0x4c, data }
+    return { op: 0x4d, data }
+  }
+
+  const chunks: { op: number; data?: number[] }[] = [
+    { op: pubKeyBytes.length, data: pubKeyBytes },
+    { op: 0xac } // OP_CHECKSIG
+  ]
+
+  for (const field of fields) chunks.push(encodeChunk(field))
+
+  let notYetDropped = fields.length
+  while (notYetDropped > 1) { chunks.push({ op: 0x6d }); notYetDropped -= 2 } // OP_2DROP
+  if (notYetDropped !== 0) chunks.push({ op: 0x75 }) // OP_DROP
+
+  return new LockingScript(chunks)
+}
+
+describe('UMPLookupService', () => {
+  let mongod: MongoMemoryServer
+  let client: MongoClient
+  let db: Db
+  let service: ReturnType<typeof UMPLookupServiceFactory>
+
+  beforeEach(async () => {
+    mongod = await MongoMemoryServer.create()
+    const uri = mongod.getUri()
+    client = new MongoClient(uri)
+    await client.connect()
+    db = client.db('test')
+    service = UMPLookupServiceFactory(db)
+  })
+
+  afterEach(async () => {
+    await client.close()
+    await mongod.stop()
+  })
+
+  // Helper to create core UMP fields
+  const createCoreFields = (): number[][] => {
+    return [
+      Utils.toArray('salt123', 'utf8'),                    // 0
+      Utils.toArray('pp1', 'utf8'),                        // 1
+      Utils.toArray('pr1', 'utf8'),                        // 2
+      Utils.toArray('rp1', 'utf8'),                        // 3
+      Utils.toArray('pp2', 'utf8'),                        // 4
+      Utils.toArray('rp2', 'utf8'),                        // 5
+      Utils.toArray('presentationHash123', 'utf8'),        // 6
+      Utils.toArray('recoveryHash456', 'utf8'),            // 7
+      Utils.toArray('pke', 'utf8'),                        // 8
+      Utils.toArray('pwke', 'utf8'),                       // 9
+      Utils.toArray('rke', 'utf8')                         // 10
+    ]
+  }
+
+  describe('Legacy Token Storage', () => {
+    it('should store legacy token record', async () => {
+      const fields = createCoreFields()
+      const lockingScript = buildPushDropScript(fields)
+
+      await service.outputAdmittedByTopic({
+        mode: 'locking-script',
+        txid: 'abc123',
+        outputIndex: 0,
+        topic: 'tm_users',
+        satoshis: 1,
+        lockingScript
+      })
+
+      const collection = db.collection<UMPRecord>('ump')
+      const record = await collection.findOne({ txid: 'abc123' })
+
+      expect(record).toBeTruthy()
+      expect(record!.txid).toBe('abc123')
+      expect(record!.outputIndex).toBe(0)
+      expect(record!.presentationHash).toBe(Utils.toHex(fields[6]))
+      expect(record!.recoveryHash).toBe(Utils.toHex(fields[7]))
+      expect(record!.umpVersion).toBeUndefined()
+      expect(record!.kdfAlgorithm).toBeUndefined()
+    })
+
+    it('should store legacy token with profiles', async () => {
+      const fields = createCoreFields()
+      fields.push(Utils.toArray('encrypted profiles data', 'utf8')) // field 11
+
+      const lockingScript = buildPushDropScript(fields)
+
+      await service.outputAdmittedByTopic({
+        mode: 'locking-script',
+        txid: 'def456',
+        outputIndex: 1,
+        topic: 'tm_users',
+        satoshis: 1,
+        lockingScript
+      })
+
+      const collection = db.collection<UMPRecord>('ump')
+      const record = await collection.findOne({ txid: 'def456' })
+
+      expect(record).toBeTruthy()
+      expect(record!.umpVersion).toBeUndefined() // Still legacy (no v3 fields)
+    })
+  })
+
+  describe('Version 3 Token Storage', () => {
+    it('should store v3 token with Argon2id metadata', async () => {
+      const fields = createCoreFields()
+      fields.push(Utils.toArray('profiles', 'utf8')) // field 11
+      fields.push([3]) // field 12: umpVersion
+      fields.push(Utils.toArray('argon2id', 'utf8')) // field 13: kdfAlgorithm
+      const kdfParams = JSON.stringify({
+        iterations: 7,
+        memoryKiB: 131072,
+        parallelism: 1,
+        hashLength: 32
+      })
+      fields.push(Utils.toArray(kdfParams, 'utf8')) // field 14: kdfParams
+
+      const lockingScript = buildPushDropScript(fields)
+
+      await service.outputAdmittedByTopic({
+        mode: 'locking-script',
+        txid: 'v3token123',
+        outputIndex: 0,
+        topic: 'tm_users',
+        satoshis: 1,
+        lockingScript
+      })
+
+      const collection = db.collection<UMPRecord>('ump')
+      const record = await collection.findOne({ txid: 'v3token123' })
+
+      expect(record).toBeTruthy()
+      expect(record!.umpVersion).toBe(3)
+      expect(record!.kdfAlgorithm).toBe('argon2id')
+      expect(record!.kdfIterations).toBe(7)
+    })
+
+    it('should store v3 token with PBKDF2 metadata', async () => {
+      const fields = createCoreFields()
+      fields.push([3]) // No profiles
+      fields.push(Utils.toArray('pbkdf2-sha512', 'utf8'))
+      fields.push(Utils.toArray(JSON.stringify({ iterations: 7777 }), 'utf8'))
+
+      const lockingScript = buildPushDropScript(fields)
+
+      await service.outputAdmittedByTopic({
+        mode: 'locking-script',
+        txid: 'v3pbkdf2',
+        outputIndex: 0,
+        topic: 'tm_users',
+        satoshis: 1,
+        lockingScript
+      })
+
+      const collection = db.collection<UMPRecord>('ump')
+      const record = await collection.findOne({ txid: 'v3pbkdf2' })
+
+      expect(record).toBeTruthy()
+      expect(record!.umpVersion).toBe(3)
+      expect(record!.kdfAlgorithm).toBe('pbkdf2-sha512')
+      expect(record!.kdfIterations).toBe(7777)
+    })
+
+    it('should handle malformed kdfParams gracefully', async () => {
+      const fields = createCoreFields()
+      fields.push([3])
+      fields.push(Utils.toArray('argon2id', 'utf8'))
+      fields.push(Utils.toArray('invalid json', 'utf8'))
+
+      const lockingScript = buildPushDropScript(fields)
+
+      await service.outputAdmittedByTopic({
+        mode: 'locking-script',
+        txid: 'malformed',
+        outputIndex: 0,
+        topic: 'tm_users',
+        satoshis: 1,
+        lockingScript
+      })
+
+      const collection = db.collection<UMPRecord>('ump')
+      const record = await collection.findOne({ txid: 'malformed' })
+
+      expect(record).toBeTruthy()
+      expect(record!.umpVersion).toBe(3)
+      expect(record!.kdfAlgorithm).toBe('argon2id')
+      expect(record!.kdfIterations).toBeUndefined() // Failed to parse
+    })
+  })
+
+  describe('Lookup Queries', () => {
+    beforeEach(async () => {
+      // Insert test records
+      const collection = db.collection<UMPRecord>('ump')
+      await collection.insertMany([
+        {
+          txid: 'legacy1',
+          outputIndex: 0,
+          presentationHash: 'aabbcc',
+          recoveryHash: 'ddeeff'
+        },
+        {
+          txid: 'v3token1',
+          outputIndex: 0,
+          presentationHash: '112233',
+          recoveryHash: '445566',
+          umpVersion: 3,
+          kdfAlgorithm: 'argon2id',
+          kdfIterations: 7
+        }
+      ])
+    })
+
+    it('should query by presentationHash', async () => {
+      const result = await service.lookup({
+        query: { presentationHash: 'aabbcc' }
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].txid).toBe('legacy1')
+      expect(result[0].outputIndex).toBe(0)
+    })
+
+    it('should query by recoveryHash', async () => {
+      const result = await service.lookup({
+        query: { recoveryHash: '445566' }
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].txid).toBe('v3token1')
+    })
+
+    it('should query by outpoint', async () => {
+      const result = await service.lookup({
+        query: { outpoint: 'legacy1.0' }
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].txid).toBe('legacy1')
+    })
+
+    it('should return empty array for non-existent query', async () => {
+      const result = await service.lookup({
+        query: { presentationHash: 'nonexistent' }
+      })
+
+      expect(result).toEqual([])
+    })
+
+    it('should throw error for missing query', async () => {
+      await expect(service.lookup({})).rejects.toThrow('Lookup must include a valid query')
+    })
+
+    it('should throw error for invalid query parameters', async () => {
+      await expect(
+        service.lookup({ query: { invalidParam: 'test' } })
+      ).rejects.toThrow('Query parameters must include')
+    })
+
+    it('should return newest record when multiple exist', async () => {
+      const collection = db.collection<UMPRecord>('ump')
+      await collection.insertMany([
+        {
+          txid: 'old',
+          outputIndex: 0,
+          presentationHash: 'same',
+          recoveryHash: 'hash1'
+        },
+        {
+          txid: 'new',
+          outputIndex: 0,
+          presentationHash: 'same',
+          recoveryHash: 'hash2'
+        }
+      ])
+
+      const result = await service.lookup({
+        query: { presentationHash: 'same' }
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].txid).toBe('new') // Newest by _id
+    })
+  })
+
+  describe('Output Management', () => {
+    it('should delete record on outputSpent', async () => {
+      const collection = db.collection<UMPRecord>('ump')
+      await collection.insertOne({
+        txid: 'toSpend',
+        outputIndex: 0,
+        presentationHash: 'hash',
+        recoveryHash: 'hash2'
+      })
+
+      await service.outputSpent({
+        mode: 'none',
+        topic: 'tm_users',
+        txid: 'toSpend',
+        outputIndex: 0
+      })
+
+      const record = await collection.findOne({ txid: 'toSpend' })
+      expect(record).toBeNull()
+    })
+
+    it('should delete record on outputEvicted', async () => {
+      const collection = db.collection<UMPRecord>('ump')
+      await collection.insertOne({
+        txid: 'toEvict',
+        outputIndex: 0,
+        presentationHash: 'hash',
+        recoveryHash: 'hash2'
+      })
+
+      await service.outputEvicted('toEvict', 0)
+
+      const record = await collection.findOne({ txid: 'toEvict' })
+      expect(record).toBeNull()
+    })
+  })
+
+  describe('Metadata', () => {
+    it('should return correct metadata', async () => {
+      const metadata = await service.getMetaData()
+
+      expect(metadata.name).toBe('UMP Lookup Service')
+      expect(metadata.shortDescription).toBe('Lookup Service for User Management Protocol tokens')
+    })
+
+    it('should return documentation', async () => {
+      const docs = await service.getDocumentation()
+
+      expect(docs).toContain('User Management Protocol')
+      expect(docs).toContain('presentationHash')
+      expect(docs).toContain('recoveryHash')
+    })
+  })
+})

--- a/backend/src/__tests/UMPTopicManager.test.ts
+++ b/backend/src/__tests/UMPTopicManager.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from '@jest/globals'
+import UMPTopicManager from '../topic-managers/UMPTopicManager.js'
+import { Transaction, Utils, PrivateKey, LockingScript } from '@bsv/sdk'
+
+// Builds a PushDrop-formatted locking script without needing a real wallet
+function buildPushDropScript(fields: number[][]): LockingScript {
+  const pubKeyBytes = PrivateKey.fromRandom().toPublicKey().toDER() as number[]
+
+  const encodeChunk = (data: number[]): { op: number; data?: number[] } => {
+    if (data.length === 0) return { op: 0 }
+    if (data.length === 1 && data[0] === 0) return { op: 0 }
+    if (data.length === 1 && data[0] > 0 && data[0] <= 16) return { op: 0x50 + data[0] }
+    if (data.length === 1 && data[0] === 0x81) return { op: 0x4f }
+    if (data.length <= 75) return { op: data.length, data }
+    if (data.length <= 255) return { op: 0x4c, data }
+    return { op: 0x4d, data }
+  }
+
+  const chunks: { op: number; data?: number[] }[] = [
+    { op: pubKeyBytes.length, data: pubKeyBytes },
+    { op: 0xac } // OP_CHECKSIG
+  ]
+
+  for (const field of fields) chunks.push(encodeChunk(field))
+
+  let notYetDropped = fields.length
+  while (notYetDropped > 1) { chunks.push({ op: 0x6d }); notYetDropped -= 2 } // OP_2DROP
+  if (notYetDropped !== 0) chunks.push({ op: 0x75 }) // OP_DROP
+
+  return new LockingScript(chunks)
+}
+
+describe('UMPTopicManager', () => {
+  const manager = new UMPTopicManager()
+
+  // Helper to create a mock UMP token transaction
+  const createMockUMPTransaction = (fields: number[][]): number[] => {
+    // Create a minimal transaction with UMP token output
+    const tx = new Transaction(1, [], [])
+
+    // Create PushDrop locking script
+    const mockLockingScript = buildPushDropScript(fields)
+
+    tx.addOutput({
+      satoshis: 1,
+      lockingScript: mockLockingScript
+    })
+
+    return tx.toBEEF()
+  }
+
+  // Helper to create core UMP fields (fields 0-10)
+  const createCoreFields = (): number[][] => {
+    return [
+      Utils.toArray('passwordSalt', 'utf8'),                    // 0
+      Utils.toArray('passwordPresentationPrimary', 'utf8'),     // 1
+      Utils.toArray('passwordRecoveryPrimary', 'utf8'),         // 2
+      Utils.toArray('presentationRecoveryPrimary', 'utf8'),     // 3
+      Utils.toArray('passwordPrimaryPrivileged', 'utf8'),       // 4
+      Utils.toArray('presentationRecoveryPrivileged', 'utf8'),  // 5
+      Utils.toArray('presentationHash', 'utf8'),                // 6
+      Utils.toArray('recoveryHash', 'utf8'),                    // 7
+      Utils.toArray('presentationKeyEncrypted', 'utf8'),        // 8
+      Utils.toArray('passwordKeyEncrypted', 'utf8'),            // 9
+      Utils.toArray('recoveryKeyEncrypted', 'utf8')             // 10
+    ]
+  }
+
+  describe('Legacy Token Validation', () => {
+    it('should admit valid legacy token with 11 core fields', async () => {
+      const fields = createCoreFields()
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([0])
+      expect(result.coinsToRetain).toEqual([])
+    })
+
+    it('should admit legacy token with profiles (field 11)', async () => {
+      const fields = createCoreFields()
+      fields.push(Utils.toArray('encryptedProfiles', 'utf8')) // field 11
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([0])
+    })
+
+    it('should reject token with fewer than 11 fields', async () => {
+      const fields = createCoreFields().slice(0, 10) // Only 10 fields
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([])
+      expect(result.coinsToRetain).toEqual([])
+    })
+  })
+
+  describe('Version 3 Token Validation', () => {
+    it('should admit valid v3 token with Argon2id', async () => {
+      const fields = createCoreFields()
+      fields.push(Utils.toArray('encryptedProfiles', 'utf8')) // field 11 (optional)
+      fields.push([3]) // field 12: umpVersion = 3
+      fields.push(Utils.toArray('argon2id', 'utf8')) // field 13: kdfAlgorithm
+      const kdfParams = JSON.stringify({
+        iterations: 7,
+        memoryKiB: 131072,
+        parallelism: 1,
+        hashLength: 32
+      })
+      fields.push(Utils.toArray(kdfParams, 'utf8')) // field 14: kdfParams
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([0])
+    })
+
+    it('should admit valid v3 token with PBKDF2', async () => {
+      const fields = createCoreFields()
+      fields.push([3]) // field 12: umpVersion = 3 (no profiles)
+      fields.push(Utils.toArray('pbkdf2-sha512', 'utf8')) // field 13
+      const kdfParams = JSON.stringify({ iterations: 7777 })
+      fields.push(Utils.toArray(kdfParams, 'utf8')) // field 14
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([0])
+    })
+
+    it('should reject v3 token with invalid umpVersion', async () => {
+      const fields = createCoreFields()
+      fields.push([5]) // Invalid version
+      fields.push(Utils.toArray('argon2id', 'utf8'))
+      fields.push(Utils.toArray(JSON.stringify({ iterations: 7 }), 'utf8'))
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([])
+    })
+
+    it('should reject v3 token with missing kdfAlgorithm', async () => {
+      const fields = createCoreFields()
+      fields.push([3]) // umpVersion
+      // Missing field 13 (kdfAlgorithm)
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([])
+    })
+
+    it('should reject v3 token with unsupported kdfAlgorithm', async () => {
+      const fields = createCoreFields()
+      fields.push([3])
+      fields.push(Utils.toArray('scrypt', 'utf8')) // Unsupported
+      fields.push(Utils.toArray(JSON.stringify({ iterations: 7 }), 'utf8'))
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([])
+    })
+
+    it('should reject v3 token with missing kdfParams', async () => {
+      const fields = createCoreFields()
+      fields.push([3])
+      fields.push(Utils.toArray('argon2id', 'utf8'))
+      // Missing field 14 (kdfParams)
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([])
+    })
+
+    it('should reject v3 token with malformed kdfParams JSON', async () => {
+      const fields = createCoreFields()
+      fields.push([3])
+      fields.push(Utils.toArray('argon2id', 'utf8'))
+      fields.push(Utils.toArray('not valid json', 'utf8'))
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([])
+    })
+
+    it('should reject v3 token with invalid kdfParams iterations', async () => {
+      const fields = createCoreFields()
+      fields.push([3])
+      fields.push(Utils.toArray('argon2id', 'utf8'))
+      fields.push(Utils.toArray(JSON.stringify({ iterations: 0 }), 'utf8')) // Invalid: must be positive
+
+      const beef = createMockUMPTransaction(fields)
+
+      const result = await manager.identifyAdmissibleOutputs(beef, [])
+
+      expect(result.outputsToAdmit).toEqual([])
+    })
+  })
+
+  describe('Metadata', () => {
+    it('should return correct metadata', async () => {
+      const metadata = await manager.getMetaData()
+
+      expect(metadata.name).toBe('User Management Protocol')
+      expect(metadata.shortDescription).toBe('Manages CWI-style wallet account descriptors.')
+    })
+
+    it('should return documentation', async () => {
+      const docs = await manager.getDocumentation()
+
+      expect(docs).toContain('User Management Protocol')
+      expect(docs).toContain('Version 3')
+    })
+  })
+})

--- a/backend/src/lookup-services/UMPLookupDocs.md.ts
+++ b/backend/src/lookup-services/UMPLookupDocs.md.ts
@@ -1,5 +1,26 @@
 export default `# User Management Protocol Lookup Service
 
-To use this service, send a query that comprises an outpoint, presentationHash, or recoeryHash.
+Query UMP tokens by presentation key hash, recovery key hash, or outpoint.
 
-The associated token will be returned.`
+## Query Parameters
+
+- **presentationHash**: SHA-256 hash of the presentation key (hex string)
+- **recoveryHash**: SHA-256 hash of the recovery key (hex string)
+- **outpoint**: Transaction outpoint in format "txid.outputIndex"
+
+## Response
+
+Returns the most recent UTXO reference for the queried token:
+- txid
+- outputIndex
+
+## Stored Metadata
+
+The lookup service indexes:
+- presentationHash (field 6)
+- recoveryHash (field 7)
+- umpVersion (v3 tokens only)
+- kdfAlgorithm (v3 tokens only)
+- kdfIterations (v3 tokens only)
+
+Legacy query compatibility is maintained for all token versions.`

--- a/backend/src/lookup-services/UMPLookupServiceFactory.ts
+++ b/backend/src/lookup-services/UMPLookupServiceFactory.ts
@@ -34,17 +34,48 @@ class UMPLookupService implements LookupService {
     // Decode the UMP fields from the Bitcoin outputScript
     const result = PushDrop.decode(lockingScript)
 
-    // UMP Account Fields to store (from the UMP protocol's PushDrop field order)
-    const presentationHash = Utils.toHex(result.fields[6])
-    const recoveryHash = Utils.toHex(result.fields[7])
+    // Parse protocol fields (excluding trailing signature)
+    const protocolFields = result.fields
 
-    // Store UMP fields in db
-    await this.records.insertOne({
+    // UMP Account Fields to store (from the UMP protocol's PushDrop field order)
+    const presentationHash = Utils.toHex(protocolFields[6])
+    const recoveryHash = Utils.toHex(protocolFields[7])
+
+    // Detect v3 token: umpVersion is a single byte at field[11] (no profiles)
+    // or field[12] (with profiles). Multi-byte fields[11] means profiles present.
+    const hasV3AtIndex11 = protocolFields.length >= 12 && protocolFields[11]?.length === 1
+    const hasV3AtIndex12 = !hasV3AtIndex11 && protocolFields.length >= 13 && protocolFields[12]?.length === 1
+    const hasV3Candidate = hasV3AtIndex11 || hasV3AtIndex12
+    const v3VersionIndex = hasV3AtIndex12 ? 12 : 11
+
+    const record: UMPRecord = {
       txid,
       outputIndex,
       presentationHash,
       recoveryHash
-    })
+    }
+
+    // Add v3 metadata if present
+    if (hasV3Candidate) {
+      record.umpVersion = protocolFields[v3VersionIndex][0]
+
+      const kdfAlgIndex = v3VersionIndex + 1
+      const kdfParamsIndex = v3VersionIndex + 2
+
+      const kdfAlgorithm = new TextDecoder().decode(new Uint8Array(protocolFields[kdfAlgIndex]))
+      record.kdfAlgorithm = kdfAlgorithm
+
+      const kdfParamsJson = new TextDecoder().decode(new Uint8Array(protocolFields[kdfParamsIndex]))
+      try {
+        const kdfParams = JSON.parse(kdfParamsJson)
+        record.kdfIterations = kdfParams.iterations
+      } catch (e) {
+        console.warn('Failed to parse kdfParams during storage:', e)
+      }
+    }
+
+    // Store UMP fields in db
+    await this.records.insertOne(record)
   }
 
   async outputSpent(payload: OutputSpent) {

--- a/backend/src/topic-managers/UMPTopicDocs.md.ts
+++ b/backend/src/topic-managers/UMPTopicDocs.md.ts
@@ -1,7 +1,26 @@
-export default `# User Management Protocol Topic Manager Docs
+export default `# User Management Protocol Topic Manager
 
-To have outputs accepted into the Meter overlay network, use the Meter sCrypt contract to create valid locking scripts.
+The UMP Topic Manager validates and admits User Management Protocol tokens to the overlay network.
 
-Submit transactions that start new meters at 1, or spend existing meters already submitted.
+## Accepted Token Formats
 
-The latest state of all meters will be tracked, and will be available through the corresponding Meter Lookup Service.`
+### Legacy Tokens
+- Minimum 11 PushDrop fields (fields 0-10)
+- Optional field 11: encrypted profiles
+- Uses PBKDF2 (7777 rounds) for password key derivation
+
+### Version 3 Tokens (Current)
+- Fields 0-10: core UMP fields (unchanged)
+- Field 11: encrypted profiles (optional)
+- Field 12: umpVersion (single byte, value 3)
+- Field 13: kdfAlgorithm (UTF-8, "argon2id" or "pbkdf2-sha512")
+- Field 14: kdfParams (UTF-8 JSON with iterations, memoryKiB, parallelism, hashLength)
+
+## Validation
+
+The topic manager validates:
+1. Minimum 11 fields present
+2. For v3 tokens: validates KDF metadata structure and values
+3. Signature field (if present) is excluded from protocol field parsing
+
+Submit UMP token transactions to update or create user account descriptors on-chain.`

--- a/backend/src/topic-managers/UMPTopicManager.ts
+++ b/backend/src/topic-managers/UMPTopicManager.ts
@@ -21,6 +21,7 @@ export default class UMPTopicManager implements TopicManager {
 
   /**
    * Returns the outputs from the UMP transaction that are admissible.
+   * Validates both legacy tokens and v3 tokens with KDF metadata.
    */
   async identifyAdmissibleOutputs(beef: number[], previousCoins: number[]): Promise<AdmittanceInstructions> {
     try {
@@ -37,13 +38,63 @@ export default class UMPTopicManager implements TopicManager {
         // Decode the UMP account fields
         try {
           const result = PushDrop.decode(output.lockingScript)
-          if (result.fields.length < 11) { // UMP tokens have 11 fields
-            throw new Error('Invalid UMP token')
+
+          // Parse protocol fields (excluding trailing signature)
+          const protocolFields = result.fields
+
+          // Minimum fields check: need at least 11 core fields
+          if (protocolFields.length < 11) {
+            throw new Error('Invalid UMP token: insufficient fields')
           }
+
+          // Detect v3 token: umpVersion is a single byte at field[11] (no profiles)
+          // or field[12] (with profiles). Multi-byte fields[11] means profiles present.
+          const hasV3AtIndex11 = protocolFields.length >= 12 && protocolFields[11]?.length === 1
+          const hasV3AtIndex12 = !hasV3AtIndex11 && protocolFields.length >= 13 && protocolFields[12]?.length === 1
+          const hasV3Candidate = hasV3AtIndex11 || hasV3AtIndex12
+          const v3VersionIndex = hasV3AtIndex12 ? 12 : 11
+
+          // If v3 token detected, validate KDF metadata
+          if (hasV3Candidate) {
+            // Validate umpVersion
+            if (protocolFields[v3VersionIndex][0] !== 3) {
+              throw new Error('Invalid UMP v3 token: umpVersion must be 3')
+            }
+
+            const kdfAlgIndex = v3VersionIndex + 1
+            const kdfParamsIndex = v3VersionIndex + 2
+
+            // Validate kdfAlgorithm field exists and is valid UTF-8
+            if (!protocolFields[kdfAlgIndex] || protocolFields[kdfAlgIndex].length === 0) {
+              throw new Error('Invalid UMP v3 token: missing kdfAlgorithm')
+            }
+            const kdfAlgorithm = new TextDecoder().decode(new Uint8Array(protocolFields[kdfAlgIndex]))
+            if (kdfAlgorithm !== 'argon2id' && kdfAlgorithm !== 'pbkdf2-sha512') {
+              throw new Error(`Invalid UMP v3 token: unsupported kdfAlgorithm "${kdfAlgorithm}"`)
+            }
+
+            // Validate kdfParams field exists and is valid JSON
+            if (!protocolFields[kdfParamsIndex] || protocolFields[kdfParamsIndex].length === 0) {
+              throw new Error('Invalid UMP v3 token: missing kdfParams')
+            }
+            const kdfParamsJson = new TextDecoder().decode(new Uint8Array(protocolFields[kdfParamsIndex]))
+            try {
+              const kdfParams = JSON.parse(kdfParamsJson)
+              if (!kdfParams.iterations || kdfParams.iterations <= 0) {
+                throw new Error('Invalid UMP v3 token: kdfParams.iterations must be positive')
+              }
+            } catch (e) {
+              throw new Error(`Invalid UMP v3 token: malformed kdfParams JSON - ${(e as Error).message}`)
+            }
+          }
+
+          // Token is valid (legacy or v3)
           outputs.push(i)
         } catch (error) {
+          console.warn(`Output ${i} failed UMP validation:`, error)
         }
       }
+
       if (outputs.length === 0) {
         throw new Error(
           'This transaction does not publish a valid CWI account descriptor!'

--- a/backend/src/topic-managers/UMPTopicManager.ts
+++ b/backend/src/topic-managers/UMPTopicManager.ts
@@ -25,13 +25,8 @@ export default class UMPTopicManager implements TopicManager {
    */
   async identifyAdmissibleOutputs(beef: number[], previousCoins: number[]): Promise<AdmittanceInstructions> {
     try {
-      console.log('previous UTXOs', previousCoins.length)
       const outputs: number[] = []
       const parsedTransaction = Transaction.fromBEEF(beef)
-      const previousUTXOs = previousCoins.map(x => ({
-        txid: (parsedTransaction.inputs[x].sourceTXID || parsedTransaction.inputs[x].sourceTransaction?.id('hex')) as string,
-        outputIndex: parsedTransaction.inputs[x].sourceOutputIndex
-      }))
 
       // Try to decode and validate transaction outputs
       for (const [i, output] of parsedTransaction.outputs.entries()) {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -3,6 +3,10 @@ export interface UMPRecord {
   outputIndex: number
   presentationHash: string
   recoveryHash: string
+  // V3 metadata fields (optional for legacy tokens)
+  umpVersion?: number
+  kdfAlgorithm?: string
+  kdfIterations?: number
 }
 
 export interface UTXOReference {

--- a/backend/tsconfig.jest.json
+++ b/backend/tsconfig.jest.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "baseUrl": "./",
+    "module": "CommonJS",
+    "moduleResolution": "node"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "dist"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,20 +76,20 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.8.6.tgz",
-      "integrity": "sha512-gJf3sPs1shMRAi5ThlYTix/AsKtSlZIPAzrUd/5HpTIoThAqwB6H5kf8AelZXcXjwNbhzVvKHzq81VogOc9Q5g==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.10.4.tgz",
+      "integrity": "sha512-NuEXWwtuZ3WbER9wLtm33QCfhVwLyTyAzGholOeHo1imNDLLe7d2HADmf8hlSqAkNud3Y03S2poRc6aJMRWDrA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@bsv/wallet-toolbox-client": {
-      "version": "1.6.32",
-      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-1.6.32.tgz",
-      "integrity": "sha512-DzY7yIkQQRRsyf+DBLpudiphE5Vho7oCX8RU/bc2FveRLfYY/yT/0Gn4048hh9wATG+YZ+qoC+sRvuUXl71WQA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-1.8.3.tgz",
+      "integrity": "sha512-D1kLyJ97PpdvzIlgufV4sFd6evftxTK7pqQuQSZR0o6cWl/YMNpS4nbPgU1OfDrV6T/lajGpX2tNAok2xc+CPw==",
       "dev": true,
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
-        "@bsv/sdk": "^1.8.6",
+        "@bsv/sdk": "^1.9.29",
         "idb": "^8.0.2"
       }
     },
@@ -884,14 +884,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -1533,9 +1533,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2326,10 +2326,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -2723,15 +2724,19 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yauzl": {


### PR DESCRIPTION
## Description of Changes

Add UMP v3 token support to the overlay backend — topic manager and lookup service
now parse and validate KDF metadata fields (umpVersion, kdfAlgorithm, kdfParams)
from on-chain tokens.

Fixes a v3 detection bug where tokens without an encrypted-profiles field had
umpVersion at field index 11 (not 12), causing them to be treated as legacy tokens.
Detection now checks both layouts: single-byte at field[11] = v3 without profiles,
single-byte at field[12] = v3 with profiles.

Also adds a Jest test suite with 29 unit tests covering both the topic manager and
lookup service, including legacy tokens, v3 tokens with and without profiles, and
invalid/edge-case inputs. Includes the Jest/ts-jest configuration needed to run
tests in this LARS project structure.

## Linked Issues / Tickets

n/a

## Testing Procedure

New unit tests in `backend/src/__tests/`:

- `UMPTopicManager.test.ts` — validates admission logic for legacy tokens, v3 tokens
  (with/without profiles), insufficient fields, invalid KDF metadata, and
  unsupported KDF algorithms
- `UMPLookupServiceFactory.test.ts` — validates indexing and lookup of presentation
  hash, recovery hash, and outpoint for both legacy and v3 tokens

- [x] I have added new unit tests
- [x] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged